### PR TITLE
publish first version of package to pypi

### DIFF
--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -67,7 +67,7 @@ jobs:
         if: ${{ steps.check-version.outputs.changed == 'true' }}
         run: poetry build
 
-      # TODO: switch to official Amino Pypi account (using tim.estes@briq.com's right now)
+      # TODO: switch to official Amino Pypi account
       - name: Publish to PyPI
         if: ${{ steps.check-version.outputs.changed == 'true' }}
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -67,10 +67,7 @@ jobs:
         if: ${{ steps.check-version.outputs.changed == 'true' }}
         run: poetry build
 
-      # commenting out until we get offical Amino organization in PYPI
-      # - name: Publish to PyPI
-      #   if: ${{ steps.check-version.outputs.changed == 'true' }}
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     user: __token__
-      #     password: ${{ secrets.PYPI_TOKEN }} #TODO: addd PYPI_TOKEN in projecte secrets
+      # TODO: switch to official Amino Pypi account (using tim.estes@briq.com's right now)
+      - name: Publish to PyPI
+        if: ${{ steps.check-version.outputs.changed == 'true' }}
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-partifact-plugin"
-version = "0.1.0"
+version = "0.1.1"
 description = "A poetry plugin that configures AWS CodeArtifact"
 authors = ["Amino Engineering Team <eng@amino.com>"]
 readme = "README.md"


### PR DESCRIPTION
Since it doesn't look like Amino is going to get an organization is Pypi anytime soon, I'm deciding to publish the package to my personal Pypy.

Once Amino does get approved and added as an org, I'm going to remove the project from my Pypy and re-publish it.

Authentication done through Pypi's [trusted publishers](https://docs.pypi.org/trusted-publishers/).

<img width="1090" alt="image" src="https://github.com/aminohealth/poetry-partifact-plugin/assets/33536315/2f753d00-373b-4414-ba49-908fa8bd18c8">
